### PR TITLE
Remove the escape delay when trying to exit insert mode

### DIFF
--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -1,8 +1,12 @@
 " Code from:
 " http://stackoverflow.com/questions/5585129/pasting-code-into-terminal-window-into-vim-on-mac-os-x
 " then https://coderwall.com/p/if9mda
+" and then https://github.com/aaronjensen/vimfiles/blob/59a7019b1f2d08c70c28a41ef4e2612470ea0549/plugin/terminaltweaks.vim
+" to fix the escape time problem with insert mode.
 " Docs on bracketed paste mode:
 " http://www.xfree86.org/current/ctlseqs.html
+" Docs on mapping fast escape codes in vim
+" http://vim.wikia.com/wiki/Mapping_fast_keycodes_in_terminal_Vim
 if &term =~ "xterm.*" || &term =~ "screen*"
   function! WrapForTmux(s)
     if !exists('$TMUX')
@@ -18,10 +22,17 @@ if &term =~ "xterm.*" || &term =~ "screen*"
   let &t_SI .= WrapForTmux("\<Esc>[?2004h")
   let &t_EI .= WrapForTmux("\<Esc>[?2004l")
 
-  function! XTermPasteBegin()
+  function! XTermPasteBegin(ret)
     set pastetoggle=<Esc>[201~
     set paste
-    return ""
+    return a:ret
   endfunction
-  inoremap <special> <expr> <Esc>[200~ XTermPasteBegin()
+
+  execute "set <f28>=\<Esc>[200~"
+  execute "set <f29>=\<Esc>[201~"
+  map <expr> <f28> XTermPasteBegin("i")
+  imap <expr> <f28> XTermPasteBegin("")
+  vmap <expr> <f28> XTermPasteBegin("c")
+  cmap <f28> <nop>
+  cmap <f29> <nop>
 endif


### PR DESCRIPTION
There is a considerable delay on exiting insert mode with the escape key. The respective links from where the fix has been adopted are below.

Do let me know I need to change anything!
