### PR TITLE
drop check for terminals

### DIFF
--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -8,32 +8,30 @@
 " http://www.xfree86.org/current/ctlseqs.html
 " Docs on mapping fast escape codes in vim
 " http://vim.wikia.com/wiki/Mapping_fast_keycodes_in_terminal_Vim
-if &term =~ "xterm.*" || &term =~ "screen*" || &term =~ "rxvt*"
-  function! WrapForTmux(s)
-    if !exists('$TMUX')
-      return a:s
-    endif
+function! WrapForTmux(s)
+  if !exists('$TMUX')
+    return a:s
+  endif
 
-    let tmux_start = "\<Esc>Ptmux;"
-    let tmux_end = "\<Esc>\\"
+  let tmux_start = "\<Esc>Ptmux;"
+  let tmux_end = "\<Esc>\\"
 
-    return tmux_start . substitute(a:s, "\<Esc>", "\<Esc>\<Esc>", 'g') . tmux_end
-  endfunction
+  return tmux_start . substitute(a:s, "\<Esc>", "\<Esc>\<Esc>", 'g') . tmux_end
+endfunction
 
-  let &t_SI .= WrapForTmux("\<Esc>[?2004h")
-  let &t_EI .= WrapForTmux("\<Esc>[?2004l")
+let &t_SI .= WrapForTmux("\<Esc>[?2004h")
+let &t_EI .= WrapForTmux("\<Esc>[?2004l")
 
-  function! XTermPasteBegin(ret)
-    set pastetoggle=<f29>
-    set paste
-    return a:ret
-  endfunction
+function! XTermPasteBegin(ret)
+  set pastetoggle=<f29>
+  set paste
+  return a:ret
+endfunction
 
-  execute "set <f28>=\<Esc>[200~"
-  execute "set <f29>=\<Esc>[201~"
-  map <expr> <f28> XTermPasteBegin("i")
-  imap <expr> <f28> XTermPasteBegin("")
-  vmap <expr> <f28> XTermPasteBegin("c")
-  cmap <f28> <nop>
-  cmap <f29> <nop>
-endif
+execute "set <f28>=\<Esc>[200~"
+execute "set <f29>=\<Esc>[201~"
+map <expr> <f28> XTermPasteBegin("i")
+imap <expr> <f28> XTermPasteBegin("")
+vmap <expr> <f28> XTermPasteBegin("c")
+cmap <f28> <nop>
+cmap <f29> <nop>


### PR DESCRIPTION
From [the original author](http://stackoverflow.com/questions/5585129/pasting-code-into-terminal-window-into-vim-on-mac-os-x/7053522#7053522):

> Note that this only enables bracketed paste mode when the `$TERM` value starts with "xterm".. you could omit the test altogether, since it isn’t strictly necessary—it’s just trying to be careful not to do something that might be incompatible with some other terminal type.

Since we don't understand yet if this is a problem, I recommend dropping the check and seeing if it comes back to bite us. Should be safe since vim has undo.

(My machine has `term` set to 'linux, and I'm reluctant to keep adding clauses to that check.)
