### PR TITLE
Check for empty $TMUX variable

### DIFF
--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -9,7 +9,7 @@
 " Docs on mapping fast escape codes in vim
 " http://vim.wikia.com/wiki/Mapping_fast_keycodes_in_terminal_Vim
 function! WrapForTmux(s)
-  if !exists('$TMUX')
+  if empty('$TMUX')
     return a:s
   endif
 


### PR DESCRIPTION
In some situations, like when running vim with sudo, $TMUX `exists()` for some reason but is empty. This causes the string "Ptmux;" to be displayed when entering and leaving insert mode.
