### PR TITLE
Revert "Check for empty $TMUX variable"

### DIFF
--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -9,7 +9,7 @@
 " Docs on mapping fast escape codes in vim
 " http://vim.wikia.com/wiki/Mapping_fast_keycodes_in_terminal_Vim
 function! WrapForTmux(s)
-  if empty('$TMUX')
+  if !exists('$TMUX')
     return a:s
   endif
 


### PR DESCRIPTION
Reverts ConradIrwin/vim-bracketed-paste#13 See #14 
