### PR TITLE
Allow disabling tmux wrap with global var

### DIFF
--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -8,8 +8,13 @@
 " http://www.xfree86.org/current/ctlseqs.html
 " Docs on mapping fast escape codes in vim
 " http://vim.wikia.com/wiki/Mapping_fast_keycodes_in_terminal_Vim
+
+if !exists("g:bracketed_paste_tmux_wrap")
+  let g:bracketed_paste_tmux_wrap = 1
+endif
+
 function! WrapForTmux(s)
-  if !exists('$TMUX')
+  if !g:bracketed_paste_tmux_wrap || !exists('$TMUX')
     return a:s
   endif
 


### PR DESCRIPTION
Make it configurable for cases where it isn't detectable.

On two different computers the plugin works when pasting from the clipboard
when running under tmux and when not.
(Ubuntu/xfce4-terminal, Mac OS X Yosemite/Terminal).

The plugin as-is does not work for me with `tmux paste-buffer -p`.

If I disable the tmux wrapping it works for me in all cases.

* Ubuntu 12.04
    * vim 7.4 (compiled locally)
    * tmux 1.9
    * xfce4-terminal 0.4.8 (Xfce 4.8)
* Mac OS X Yosemite
    * vim 7.4 (homebrew)
    * tmux 1.9a (homebrew)
    * Terminal 2.5 (343)

So I'm not sure if there's a way to detect the difference in my environments and those where the wrap is needed, but allowing a global var makes debugging (and edge cases) easier.