### PR TITLE
Keep bracketed paste enabled in normal and visual mode

### DIFF
--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -24,8 +24,8 @@ function! WrapForTmux(s)
   return tmux_start . substitute(a:s, "\<Esc>", "\<Esc>\<Esc>", 'g') . tmux_end
 endfunction
 
-let &t_SI .= WrapForTmux("\<Esc>[?2004h")
-let &t_EI .= WrapForTmux("\<Esc>[?2004l")
+let &t_ti .= WrapForTmux("\<Esc>[?2004h")
+let &t_te .= WrapForTmux("\<Esc>[?2004l")
 
 function! XTermPasteBegin(ret)
   set pastetoggle=<f29>


### PR DESCRIPTION
The mappings are already in place, but are unused without this change.
In command line mode the escape sequences are mapped to <nop>, so they
will be ignored and keeping bracketed paste enabled all the time should
cause no trouble.