### PR TITLE
Support newer tmux versions

### DIFF
--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -14,7 +14,7 @@ if !exists("g:bracketed_paste_tmux_wrap")
 endif
 
 function! WrapForTmux(s)
-  if !g:bracketed_paste_tmux_wrap || !exists('$TMUX')
+  if !g:bracketed_paste_tmux_wrap || !exists('$TMUX') || system('tmux -V')[5] >= '2'
     return a:s
   endif
 


### PR DESCRIPTION
First, it should not break anything: according to tmux's ChangeLog, then tmux
support for bracketed-paste mode dates back to 1.7.

Then, on my (tmux 2.1) system, WrapForTmux actually makes the char codes be
ignored, and a tmux error file is written. I couldn't find a trace in tmux's
ChangeLog as to when this occured, and so went with switching on the major tmux
version.