### PR TITLE
Support GNU screen

### DIFF
--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -14,14 +14,15 @@ if !exists("g:bracketed_paste_tmux_wrap")
 endif
 
 function! WrapForTmux(s)
-  if !g:bracketed_paste_tmux_wrap || !exists('$TMUX') || system('tmux -V')[5] >= '2'
+  if g:bracketed_paste_tmux_wrap && exists('$TMUX') && system('tmux -V')[5] >= '2'
+    let tmux_start = "\<Esc>Ptmux;"
+    let tmux_end = "\<Esc>\\"
+    return tmux_start . substitute(a:s, "\<Esc>", "\<Esc>\<Esc>", 'g') . tmux_end
+  elseif g:bracketed_paste_tmux_wrap && &term =~# "^screen"
+    return "\<Esc>P" . a:s . "\<Esc>\\"
+  else
     return a:s
   endif
-
-  let tmux_start = "\<Esc>Ptmux;"
-  let tmux_end = "\<Esc>\\"
-
-  return tmux_start . substitute(a:s, "\<Esc>", "\<Esc>\<Esc>", 'g') . tmux_end
 endfunction
 
 let &t_ti .= WrapForTmux("\<Esc>[?2004h")


### PR DESCRIPTION
It appears that GNU screen filters the escape sequence used to enable/disable the bracketed paste mode. So we escape it to make GNU screen pass it to the outer terminal. This is similar to how `tmux` is handled. Note that I have reused the `g:bracketed_paste_tmux_wrap` variable that enables the user to override this behavior.