### PR TITLE
Remove unused variable 'g:bracketed_paste_tmux_wrap'

### DIFF
--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -9,10 +9,6 @@
 " Docs on mapping fast escape codes in vim
 " http://vim.wikia.com/wiki/Mapping_fast_keycodes_in_terminal_Vim
 
-if !exists("g:bracketed_paste_tmux_wrap")
-  let g:bracketed_paste_tmux_wrap = 1
-endif
-
 let &t_ti .= "\<Esc>[?2004h"
 let &t_te .= "\<Esc>[?2004l"
 

--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -9,6 +9,11 @@
 " Docs on mapping fast escape codes in vim
 " http://vim.wikia.com/wiki/Mapping_fast_keycodes_in_terminal_Vim
 
+if exists("g:loaded_bracketed_paste")
+  finish
+endif
+let g:loaded_bracketed_paste = 1
+
 let &t_ti .= "\<Esc>[?2004h"
 let &t_te .= "\<Esc>[?2004l"
 


### PR DESCRIPTION
- Get rid of unused 'g: bracketed_paste_tmux_wrap' variable left from commit 363f9b62
- Add a guard variable, this allows individual users to disable plugin, and prevents unneeded
reloading of it.