### PR TITLE
going out of bracketed paste before going out of raw mode

### DIFF
--- a/plugin/bracketed-paste.vim
+++ b/plugin/bracketed-paste.vim
@@ -15,7 +15,7 @@ endif
 let g:loaded_bracketed_paste = 1
 
 let &t_ti .= "\<Esc>[?2004h"
-let &t_te .= "\<Esc>[?2004l"
+let &t_te = "\e[?2004l" . &t_te
 
 function! XTermPasteBegin(ret)
   set pastetoggle=<f29>


### PR DESCRIPTION
Like: socks on, shoes on, shoes off, socks off
Prevents echoing <F28>pasted text<F29> in command mode (in vim 8.0)