### PR TITLE
Modernize installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@ vim-bracketed-paste enables transparent pasting into vim. (i.e. no more `:set pa
 Installation
 ============
 
-I recommend using [pathogen](https://github.com/tpope/vim-pathogen). Once you have installed pathogen:
+Vim supports native package directories starting with version 8. All you have to do is clone this project under `~/.vim/pack/<any dir name>/start/vim-bracketed-paste` to have it auto-load.
+
+```bash
+mkdir -p ~/.vim/pack/dist/start
+git clone https://github.com/ConradIrwin/vim-bracketed-paste ~/.vim/pack/dist/start/vim-bracketed-paste
+```
+
+For Vim 7 and older, I recommend using [pathogen](https://github.com/tpope/vim-pathogen). Once you have installed pathogen:
 
 ```bash
 cd ~/.vim/bundle


### PR DESCRIPTION
Change recommendation to use Vim's native packaging instead of Pathogen.

You can read more about native packages here: https://shapeshed.com/vim-packages/